### PR TITLE
Fixed crash on text recognition & result object

### DIFF
--- a/src/ios/ScanditSDK.mm
+++ b/src/ios/ScanditSDK.mm
@@ -396,14 +396,14 @@
 
 - (SBSBarcodePickerState)barcodePicker:(SBSBarcodePicker *)picker
                       didRecognizeText:(SBSRecognizedText *)text {
-    NSDictionary *dict = @{ @"jsonString": text.text };
+    NSDictionary *dict = @{ @"text": text.text };
     CDVPluginResult *pluginResult = [self createResultForEvent:@"didRecognizeText" value:dict];
     int nextState = [self sendPluginResultBlocking:pluginResult];
     if (!self.continuousMode) {
         nextState = SBSPickerStateStopped;
     }
     [self switchRecognitionTextToNextState:nextState];
-    if (self.rejectedCodeIds.count > 0) {
+    if (![self.rejectedCodeIds isEqual:[NSNull null]] && self.rejectedCodeIds.count >
         text.rejected = YES;
     }
 

--- a/src/ios/ScanditSDK.mm
+++ b/src/ios/ScanditSDK.mm
@@ -403,7 +403,7 @@
         nextState = SBSPickerStateStopped;
     }
     [self switchRecognitionTextToNextState:nextState];
-    if (![self.rejectedCodeIds isEqual:[NSNull null]] && self.rejectedCodeIds.count >
+    if (![self.rejectedCodeIds isEqual:[NSNull null]] && self.rejectedCodeIds.count > 0) {
         text.rejected = YES;
     }
 


### PR DESCRIPTION
The plugin was crashing because `self.rejectedCodeIds` did not have a `count` property.

The result object property name was wrong.