### PR TITLE
Switching to active state when calling startScanning (which is the on…

### DIFF
--- a/src/android/com/mirasense/scanditsdk/plugin/FullscreenPickerController.java
+++ b/src/android/com/mirasense/scanditsdk/plugin/FullscreenPickerController.java
@@ -102,6 +102,7 @@ class FullscreenPickerController extends PickerControllerBase implements ResultR
     @Override
     public void startScanning() {
         FullScreenPickerActivity.startScanning();
+        super.setState(PickerStateMachine.ACTIVE);
     }
 
     @Override

--- a/src/android/com/mirasense/scanditsdk/plugin/SubViewPickerController.java
+++ b/src/android/com/mirasense/scanditsdk/plugin/SubViewPickerController.java
@@ -170,8 +170,13 @@ public class SubViewPickerController
                     return;
                 }
                 mPickerStateMachine.startScanning();
+                setStateOnParent(PickerStateMachine.ACTIVE);
             }
         });
+    }
+
+    private void setStateOnParent(int state) {
+        super.setState(state);
     }
 
     @Override


### PR DESCRIPTION
…ly exception that does not go over the setState function in ScanditSDK.java. Not being in the active state caused issues in the didScan callback, as mShouldBlockForDidScan was not true, so it actually did not black until the callback ended, resulting in problems like failing to reject codes.