### PR TITLE
Fix for SDK-5061

### DIFF
--- a/samples/extended/src/pages/scan/scan.ts
+++ b/samples/extended/src/pages/scan/scan.ts
@@ -48,15 +48,21 @@ export class ScanPage {
   public ionViewWillEnter(): void {
     this.subscribe();
   }
+  
+  public onPause(): void {
+    this.shouldBeScanning = false;
+  }
+  
+  public onResume(): void {
+    this.shouldBeScanning = true;
+  }
 
   public ionViewDidEnter(): void {
-    this.shouldBeScanning = true;
     this.startScanner();
     this.setScannerConstraints();
   }
 
   public ionViewWillLeave(): void {
-    this.shouldBeScanning = false;
     this.unsubscribe();
   }
 
@@ -68,6 +74,8 @@ export class ScanPage {
   private subscribe(): void {
     this.events.subscribe(this.scanner.event.scan, this.onScanHandler);
     this.events.subscribe(this.scanner.event.stateChange, this.onStateChangeHandler);
+    document.addEventListener('pause', this.onPause, false);
+    document.addEventListener('resume', this.onResume, false);
   }
 
   private unsubscribe(): void {


### PR DESCRIPTION
Should no longer add multiple pickers to the layout when waiting for permissions. Would be good if someone tested this on iOS.