### PR TITLE
Make sure constraints are refreshed when the device changes orientation

### DIFF
--- a/src/ios/ScanditSDKRotatingBarcodePicker.m
+++ b/src/ios/ScanditSDKRotatingBarcodePicker.m
@@ -36,25 +36,27 @@
 
 @implementation ScanditSDKRotatingBarcodePicker
 
-- (instancetype)initWithSettings:(SBSScanSettings *)settings{
-    if (self = [super initWithSettings:settings]) {
-        self.portraitConstraints = [[SBSConstraints alloc] init];
-        self.landscapeConstraints = [[SBSConstraints alloc] init];
+- (instancetype)initWithSettings:(SBSScanSettings *)settings {
+    self = [super initWithSettings:settings];
+    if (self) {
+        _portraitConstraints = [[SBSConstraints alloc] init];
+        _landscapeConstraints = [[SBSConstraints alloc] init];
     }
-    
     return self;
 }
 
-
 #pragma mark - Orientation Changes & Margin Adjustment
 
-- (void)willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation
-                                duration:(NSTimeInterval)duration {
-    [super willRotateToInterfaceOrientation:toInterfaceOrientation duration:duration];
-    
-    [self adjustSize:0 newOrientation:toInterfaceOrientation];
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+    UIInterfaceOrientation orientation;
+    if (size.width > size.height) {
+        orientation = UIInterfaceOrientationLandscapeLeft;
+    } else {
+        orientation = UIInterfaceOrientationPortrait;
+    }
+    [self adjustSize:0 newOrientation:orientation];
 }
-
 
 - (void)adjustSize:(CGFloat)animationDuration {
     [self adjustSize:animationDuration newOrientation:UIInterfaceOrientationUnknown];


### PR DESCRIPTION
`willRotateToInterfaceOrientation:duration:` was not getting called (maybe because we moved the picker to its own UIWindow? - that's my suspicion, but to be honest I didn’t check). Anyway, since` willRotateToInterfaceOrientation: duration:` is deprecated since iOS 8 (‼️), I updated the code to use `viewWillTransitionToSize:withTransitionCoordinator:` which is being called. Everything is fine again 🍨
