### PR TITLE
update callbacks even if the scanner is already shown

### DIFF
--- a/src/ios/ScanditSDK.mm
+++ b/src/ios/ScanditSDK.mm
@@ -89,6 +89,8 @@ SBSLicenseValidationDelegate>
 }
 
 - (void)show:(CDVInvokedUrlCommand *)command {
+    self.callbackId = command.callbackId;
+
     if (self.hasPendingOperation) {
         return;
     }
@@ -99,7 +101,6 @@ SBSLicenseValidationDelegate>
         NSLog(@"The show call received too few arguments and has to return without starting.");
         return;
     }
-    self.callbackId = command.callbackId;
 
     NSDictionary *settings = [command.arguments objectAtIndex:0];
     NSDictionary *options = [self lowerCaseOptionsFromOptions:[command.arguments objectAtIndex:1]];


### PR DESCRIPTION
Signed-off-by: Petra Donka <petra@scandit.com>

This change is required for the Enterprise Browser to implement continuous scanning properly.
When a page navigates away while the scanner was shown, a scanner is shown to which the JS context does not hold any reference (as the context is reset on every page load). To solve this, the scanner needs to be canceled/shown on every page load, depending on the circumstances. If the scanner is shown and needs to stay like that, the callbacks need to be updated (with calling `show` again), but the current implementation does not update the callbacks, as `hasPendingOperation` is true.
This change updates the `callbackId` event if `hasPendingOperation` is true, but keeps the current behaviour of the rest of the implementation.

Tested and works in the Enterprise Browser ✨ 