### PR TITLE
Code modernization

### DIFF
--- a/src/ios/ScanditSDKRotatingBarcodePicker.m
+++ b/src/ios/ScanditSDKRotatingBarcodePicker.m
@@ -235,17 +235,15 @@
     [self.manualSearchBar setDelegate:self];
     [self.manualSearchBar setTranslucent:YES];
     
-    if (NSFoundationVersionNumber >= NSFoundationVersionNumber_iOS_7_0) {
-        self.statusBarBackground = [[UIView alloc] init];
-        self.statusBarBackground.backgroundColor = [UIColor whiteColor];
-    }
-    
+    self.statusBarBackground = [[UIView alloc] init];
+    self.statusBarBackground.backgroundColor = [UIColor whiteColor];
+
     [self.view addSubview:self.manualSearchBar];
     
     [self setConstraintsForView:self.manualSearchBar toHorizontallyMatch:self.view];
     [self.view addConstraint:[self topGuideConstraintForView:self.manualSearchBar
                                                      toMatch:self
-                                                withConstant:[self navigationBarOffset]]];
+                                                withConstant:0.0f]];
     
     if (self.statusBarBackground) {
         [self.view addSubview:self.statusBarBackground];
@@ -281,41 +279,16 @@
     }
 }
 
-- (CGFloat)navigationBarOffset {
-    if ((self.navigationController && !self.navigationController.navigationBar.hidden)
-        && NSFoundationVersionNumber <= NSFoundationVersionNumber_iOS_7_1
-        && NSFoundationVersionNumber >= NSFoundationVersionNumber_iOS_7_0) {
-        UIInterfaceOrientation orientation = [[UIApplication sharedApplication] statusBarOrientation];
-        if (UIInterfaceOrientationIsLandscape(orientation)) {
-            return 32;
-        } else {
-            return 44;
-        }
-    } else {
-        return 0.0;
-    }
-}
-
 - (NSLayoutConstraint *)topGuideConstraintForView:(UIView *)view
                                           toMatch:(UIViewController *)controller
                                      withConstant:(CGFloat)constant {
-    if (NSFoundationVersionNumber >= NSFoundationVersionNumber_iOS_7_0) {
-        return [NSLayoutConstraint constraintWithItem:view
-                                            attribute:NSLayoutAttributeTop
-                                            relatedBy:NSLayoutRelationEqual
-                                               toItem:controller.topLayoutGuide
-                                            attribute:NSLayoutAttributeBottom
-                                           multiplier:1.0
-                                             constant:constant];
-    } else {
-        return [NSLayoutConstraint constraintWithItem:view
-                                            attribute:NSLayoutAttributeTop
-                                            relatedBy:NSLayoutRelationEqual
-                                               toItem:controller.view
-                                            attribute:NSLayoutAttributeTop
-                                           multiplier:1.0
-                                             constant:constant];
-    }
+    return [NSLayoutConstraint constraintWithItem:view
+                                        attribute:NSLayoutAttributeTop
+                                        relatedBy:NSLayoutRelationEqual
+                                           toItem:controller.topLayoutGuide
+                                        attribute:NSLayoutAttributeBottom
+                                       multiplier:1.0
+                                         constant:constant];
 }
 
 - (void)setConstraintsForView:(UIView *)view

--- a/src/ios/ScanditSDKSearchBar.m
+++ b/src/ios/ScanditSDKSearchBar.m
@@ -12,11 +12,9 @@
 
 #import "ScanditSDKSearchBar.h"
 
-
 @interface ScanditSDKSearchBar ()
 @property (nonatomic, strong) UIToolbar *keyboardToolbar;
 @end
-
 
 @implementation ScanditSDKSearchBar
 
@@ -43,10 +41,6 @@
     self.text = @"";
     [self setPlaceholder:placeholder];
     [self setKeyboardType:keyboardType];
-    
-    if (NSFoundationVersionNumber < NSFoundationVersionNumber_iOS_7_0) {
-        [self setBarStyle:UIBarStyleBlack];
-    }
     
     [self addConstraint:[NSLayoutConstraint constraintWithItem:self
                                                      attribute:NSLayoutAttributeHeight
@@ -104,21 +98,14 @@
  * whether the length of the entered text is long enough for a valid barcode.
  */
 - (void)updateCancelButton {
-    id barButtonAppearanceInSearchBar = [UIBarButtonItem appearanceWhenContainedIn:
-                                         [ScanditSDKSearchBar class], nil];
-    
-    // The button is only now added to the hierarchy so we update its caption.
-    if (NSFoundationVersionNumber < NSFoundationVersionNumber_iOS_7_0) {
-        UIButton *cancelButton = nil;
-        for (UIView *subView in self.subviews) {
-            if ([subView isKindOfClass:[UIButton class]]) {
-                cancelButton = (UIButton *)subView;
-                break;
-            }
-        }
-        if (cancelButton) {
-            [cancelButton setTitle:self.cancelButtonCaption forState:UIControlStateNormal];
-        }
+    id barButtonAppearanceInSearchBar;
+    if (@available(iOS 9.0, *)) {
+        barButtonAppearanceInSearchBar = [UIBarButtonItem appearanceWhenContainedInInstancesOfClasses:@[[ScanditSDKSearchBar class]]];
+    } else {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        barButtonAppearanceInSearchBar = [UIBarButtonItem appearanceWhenContainedIn:[ScanditSDKSearchBar class], nil];
+#pragma GCC diagnostic pop
     }
     
     // Adjust whether the "Go" button can be clicked.


### PR DESCRIPTION
SDK-9218

- Fix deprecated warning
- Remove iOS <8 code

This change will break compatibility with Xcode 8.x, since `@available` was introduced in Xcode 9. Hopefully no one is using Xcode 8.x 🙂