### PR TITLE
Do not use respondsToSelector on private API

### DIFF
--- a/src/ios/ScanditSDK.mm
+++ b/src/ios/ScanditSDK.mm
@@ -393,17 +393,15 @@ SBSLicenseValidationDelegate>
 }
 
 - (SBSScanSettings *)updateScanSettings:(SBSScanSettings *)scanSettings withSettings:(NSDictionary *)settings {
-    if ([scanSettings respondsToSelector:@selector(setRecognitionMode:)]) {
-        id recognitionMode = settings[@"recognitionMode"];
-        if (recognitionMode != nil && [recognitionMode isKindOfClass:[NSString class]] && [recognitionMode isEqualToString:@"text"]) {
-            scanSettings.recognitionMode = SBSRecognitionModeText;
-        } else if (recognitionMode != nil && [recognitionMode isKindOfClass:[NSString class]]) {
-            scanSettings.recognitionMode = SBSRecognitionModeCode;
-        } else if (recognitionMode != nil && [recognitionMode isKindOfClass:[NSNumber class]] && [recognitionMode isEqualToNumber:[NSNumber numberWithInt:1]]) {
-            scanSettings.recognitionMode = SBSRecognitionModeText;
-        } else if (recognitionMode != nil && [recognitionMode isKindOfClass:[NSNumber class]]) {
-            scanSettings.recognitionMode = SBSRecognitionModeCode;
-        }
+    id recognitionMode = settings[@"recognitionMode"];
+    if (recognitionMode != nil && [recognitionMode isKindOfClass:[NSString class]] && [recognitionMode isEqualToString:@"text"]) {
+        scanSettings.recognitionMode = SBSRecognitionModeText;
+    } else if (recognitionMode != nil && [recognitionMode isKindOfClass:[NSString class]]) {
+        scanSettings.recognitionMode = SBSRecognitionModeCode;
+    } else if (recognitionMode != nil && [recognitionMode isKindOfClass:[NSNumber class]] && [recognitionMode isEqualToNumber:[NSNumber numberWithInt:1]]) {
+        scanSettings.recognitionMode = SBSRecognitionModeText;
+    } else if (recognitionMode != nil && [recognitionMode isKindOfClass:[NSNumber class]]) {
+        scanSettings.recognitionMode = SBSRecognitionModeCode;
     }
 
     NSNumber *matrixScanEnabled = settings[@"matrixScanEnabled"];


### PR DESCRIPTION
recognitionMode is now always present on SBSScanSettings so no need anymore to check for it