### PR TITLE
SDC-6572 - Always present the picker modal in fullscreen

### DIFF
--- a/src/ios/ScanditSDK.mm
+++ b/src/ios/ScanditSDK.mm
@@ -231,6 +231,7 @@ SBSLicenseValidationDelegate>
                 self.scanditWindowForModal = [[UIWindow alloc] initWithFrame:frame];
                 const auto scanditController = [[UIViewController alloc] init];
                 scanditController.view.backgroundColor = [UIColor clearColor];
+                self.picker.modalPresentationStyle = UIModalPresentationFullScreen;
                 [self.scanditWindowForModal setRootViewController:scanditController];
                 [self.scanditWindowForModal setWindowLevel:UIWindowLevelNormal];
                 [self.scanditWindowForModal makeKeyAndVisible];


### PR DESCRIPTION
If the picker is presented in the iOS 13+ modal, it can be swiped down to be dismissed, which we don't want.